### PR TITLE
Improve readability of textual result

### DIFF
--- a/www/js/balance.js
+++ b/www/js/balance.js
@@ -199,11 +199,11 @@ function updateBalance() {
    var value = option.series[0].data[0].value;
 
    if(value<=1){
-    note = '<b>Résultat : les risques graves liés aux deux injections du vaccin sont supérieurs au nombre d\'admissions en réanimation que cette vaccination permet d\'éviter durant quatre mois.</b>';
+    note = '<b>Résultat :</b> le nombre d\’admissions en réanimation que cette vaccination permet d\'éviter durant quatre mois est <b>inférieur</b> aux risques graves liés aux injections du vaccin.';    
    }else if(value <=2){
-    note = '<b>Résultat : les risques graves liés aux deux injections du vaccin sont de même ordre de grandeur que le nombre d\'admissions en réanimation que cette vaccination permet d\'éviter durant quatre mois.</b>';
-   }else{
-    note = '<b>Résultat : le nombre d\’admissions en réanimation que cette vaccination permet d\'éviter durant quatre mois est plus de deux fois supérieur aux risques graves liés aux injections du vaccin.</b>';
+    note = '<b>Résultat :</b> le nombre d\’admissions en réanimation que cette vaccination permet d\'éviter durant quatre mois est <b>de même ordre de grandeur</b> que les risques graves liés aux injections du vaccin.';
+}else{
+    note = '<b>Résultat :</b> le nombre d\’admissions en réanimation que cette vaccination permet d\'éviter durant quatre mois est <b>plus de deux fois supérieur</b> aux risques graves liés aux injections du vaccin.';
    }
 
    $("#warning").html(warning+article_link);


### PR DESCRIPTION
Proposition pour améliorer la lisibilité du résultat textuel
- phrase toujours dans le même ordre "bénéfice" "comparateur" "risque"
- comparateur en gras

Cela donne


![image](https://user-images.githubusercontent.com/4091226/117974872-5a501f80-b32e-11eb-9514-3cc26dd744ad.png)
![image](https://user-images.githubusercontent.com/4091226/117974999-7fdd2900-b32e-11eb-9a60-f897881f44e9.png)
![image](https://user-images.githubusercontent.com/4091226/117974888-5fad6a00-b32e-11eb-9e7d-c420843d89ba.png)
